### PR TITLE
Adding date-time to output file names.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <pdfservices.sdk.version>3.0.0</pdfservices.sdk.version>
-    <pdfservices.sdk.samples.version>3.0.0</pdfservices.sdk.samples.version>
+    <pdfservices.sdk.version>3.0.1</pdfservices.sdk.version>
+    <pdfservices.sdk.samples.version>3.0.1</pdfservices.sdk.samples.version>
   </properties>
 
   <dependencies>

--- a/src/main/java/com/adobe/pdfservices/operation/samples/combinepdf/CombinePDF.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/combinepdf/CombinePDF.java
@@ -59,7 +59,8 @@ public class CombinePDF {
             FileRef result = combineFilesOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs(createOutputFileDirectoryPath("output/CombinePDF","Combine","pdf"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (IOException | ServiceApiException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
@@ -67,11 +68,11 @@ public class CombinePDF {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/CombinePDF/combine" + timeStamp + ".pdf");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/combinepdf/CombinePDF.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/combinepdf/CombinePDF.java
@@ -12,6 +12,8 @@
 package com.adobe.pdfservices.operation.samples.combinepdf;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import com.adobe.pdfservices.operation.ExecutionContext;
 import org.slf4j.Logger;
@@ -57,10 +59,19 @@ public class CombinePDF {
             FileRef result = combineFilesOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs("output/combineFilesOutput.pdf");
+            result.saveAs(createOutputFileDirectoryPath("output/CombinePDF","Combine","pdf"));
 
         } catch (IOException | ServiceApiException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
         }
     }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
+
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/combinepdf/CombinePDFWithPageRanges.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/combinepdf/CombinePDFWithPageRanges.java
@@ -12,6 +12,8 @@
 package com.adobe.pdfservices.operation.samples.combinepdf;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,7 +68,7 @@ public class CombinePDFWithPageRanges {
             FileRef result = combineFilesOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs("output/combineFilesWithPageOptionsOutput.pdf");
+            result.saveAs( createOutputFileDirectoryPath("output/CombinePDFWithPageRanges","Combine","pdf"));
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -94,5 +96,12 @@ public class CombinePDFWithPageRanges {
         return pageRangesForFirstFile;
     }
 
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/combinepdf/CombinePDFWithPageRanges.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/combinepdf/CombinePDFWithPageRanges.java
@@ -68,7 +68,8 @@ public class CombinePDFWithPageRanges {
             FileRef result = combineFilesOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs( createOutputFileDirectoryPath("output/CombinePDFWithPageRanges","Combine","pdf"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -97,11 +98,11 @@ public class CombinePDFWithPageRanges {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/CombinePDFWithPageRanges/combine" + timeStamp + ".pdf");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/compresspdf/CompressPDF.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/compresspdf/CompressPDF.java
@@ -54,7 +54,8 @@ public class CompressPDF {
             FileRef result = compressPDFOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs(createOutputFileDirectoryPath("output/CompressPDF", "Compress", "pdf"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -62,10 +63,10 @@ public class CompressPDF {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/CompressPDF/compress" + timeStamp + ".pdf");
     }
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/compresspdf/CompressPDF.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/compresspdf/CompressPDF.java
@@ -22,6 +22,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * This sample illustrates how to compress PDF by reducing the size of the PDF file.
@@ -52,10 +54,18 @@ public class CompressPDF {
             FileRef result = compressPDFOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs("output/compressPDFOutput.pdf");
+            result.saveAs(createOutputFileDirectoryPath("output/CompressPDF", "Compress", "pdf"));
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
         }
+    }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
     }
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/compresspdf/CompressPDFWithOptions.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/compresspdf/CompressPDFWithOptions.java
@@ -24,6 +24,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * This sample illustrates how to compress PDF by reducing the size of the PDF file on the basis of
@@ -63,10 +65,19 @@ public class CompressPDFWithOptions {
             FileRef result = compressPDFOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs("output/compressPDFWithOptionsOutput.pdf");
+            result.saveAs(createOutputFileDirectoryPath("output/CompressPDFWithOptions", "Compress", "pdf"));
+
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
         }
+    }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/compresspdf/CompressPDFWithOptions.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/compresspdf/CompressPDFWithOptions.java
@@ -65,7 +65,8 @@ public class CompressPDFWithOptions {
             FileRef result = compressPDFOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs(createOutputFileDirectoryPath("output/CompressPDFWithOptions", "Compress", "pdf"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -73,11 +74,11 @@ public class CompressPDFWithOptions {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/CompressPDFWithOptions/compress" + timeStamp + ".pdf");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromDOCX.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromDOCX.java
@@ -57,7 +57,8 @@ public class CreatePDFFromDOCX {
             FileRef result = createPdfOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs(createOutputFileDirectoryPath("output/CreatePDFFromDOCX", "Create", "pdf"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -65,11 +66,11 @@ public class CreatePDFFromDOCX {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/CreatePDFFromDOCX/create" + timeStamp + ".pdf");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromDOCX.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromDOCX.java
@@ -12,6 +12,8 @@
 package com.adobe.pdfservices.operation.samples.createpdf;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,10 +57,19 @@ public class CreatePDFFromDOCX {
             FileRef result = createPdfOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs("output/createPDFFromDOCX.pdf");
+            result.saveAs(createOutputFileDirectoryPath("output/CreatePDFFromDOCX", "Create", "pdf"));
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
         }
     }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
+
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromDOCXInputStream.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromDOCXInputStream.java
@@ -58,7 +58,8 @@ public class CreatePDFFromDOCXInputStream {
             FileRef result = createPdfOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs(createOutputFileDirectoryPath("output/CreatePDFFromDOCXInputStream", "Create", "pdf"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -70,11 +71,11 @@ public class CreatePDFFromDOCXInputStream {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/CreatePDFFromDOCXInputStream/create" + timeStamp + ".pdf");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromDOCXInputStream.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromDOCXInputStream.java
@@ -13,6 +13,8 @@ package com.adobe.pdfservices.operation.samples.createpdf;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,7 +58,7 @@ public class CreatePDFFromDOCXInputStream {
             FileRef result = createPdfOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs("output/createPDFFromDOCXStream.pdf");
+            result.saveAs(createOutputFileDirectoryPath("output/CreatePDFFromDOCXInputStream", "Create", "pdf"));
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -66,4 +68,13 @@ public class CreatePDFFromDOCXInputStream {
     private static InputStream getDOCXInputStream() {
         return CreatePDFFromDOCXInputStream.class.getClassLoader().getResourceAsStream("createPDFInput.docx");
     }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
+
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromDOCXToOutputStream.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromDOCXToOutputStream.java
@@ -76,7 +76,8 @@ public class CreatePDFFromDOCXToOutputStream {
      * @return the OutputStream instance
      */
     private static FileOutputStream prepareOutputStream() throws FileNotFoundException {
-        File file = new File(createOutputFileDirectoryPath("output/CreatePDFFromDOCXToOutputStream", "Create", "pdf"));
+        String outputFilePath = createOutputFilePath();
+        File file = new File(outputFilePath);
 
         // Create the result directories if they don't exist.
         file.getParentFile().mkdirs();
@@ -85,11 +86,11 @@ public class CreatePDFFromDOCXToOutputStream {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/CreatePDFFromDOCXToOutputStream/create" + timeStamp + ".pdf");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromDOCXToOutputStream.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromDOCXToOutputStream.java
@@ -16,6 +16,8 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,12 +76,20 @@ public class CreatePDFFromDOCXToOutputStream {
      * @return the OutputStream instance
      */
     private static FileOutputStream prepareOutputStream() throws FileNotFoundException {
-        File file = new File("output/createPDFAsStream.pdf");
+        File file = new File(createOutputFileDirectoryPath("output/CreatePDFFromDOCXToOutputStream", "Create", "pdf"));
 
         // Create the result directories if they don't exist.
         file.getParentFile().mkdirs();
 
         return new FileOutputStream(file);
+    }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromDOCXWithOptions.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromDOCXWithOptions.java
@@ -61,7 +61,8 @@ public class CreatePDFFromDOCXWithOptions {
             FileRef result = createPdfOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs(createOutputFileDirectoryPath("output/CreatePDFFromDOCXWithOptions", "Create", "pdf"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -86,11 +87,11 @@ public class CreatePDFFromDOCXWithOptions {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/CreatePDFFromDOCXWithOptions/create" + timeStamp + ".pdf");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromDOCXWithOptions.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromDOCXWithOptions.java
@@ -24,6 +24,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * This sample illustrates how to provide documentLanguage option when creating a pdf file from docx file.
@@ -59,7 +61,7 @@ public class CreatePDFFromDOCXWithOptions {
             FileRef result = createPdfOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs("output/createPDFFromDOCXWithOptionsOutput.pdf");
+            result.saveAs(createOutputFileDirectoryPath("output/CreatePDFFromDOCXWithOptions", "Create", "pdf"));
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -82,4 +84,13 @@ public class CreatePDFFromDOCXWithOptions {
 
         createPdfOperation.setOptions(wordOptions);
     }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
+
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromDynamicHTML.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromDynamicHTML.java
@@ -12,6 +12,8 @@
 package com.adobe.pdfservices.operation.samples.createpdf;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -63,7 +65,7 @@ public class CreatePDFFromDynamicHTML {
             FileRef result = htmlToPDFOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs("output/createPDFFromDynamicHtmlOutput.pdf");
+            result.saveAs(createOutputFileDirectoryPath("output/CreatePDFFromDynamicHTML", "Create", "pdf"));
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -92,6 +94,14 @@ public class CreatePDFFromDynamicHTML {
                 .withDataToMerge(dataToMerge)
                 .build();
         htmlToPDFOperation.setOptions(htmlToPdfOptions);
+    }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromDynamicHTML.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromDynamicHTML.java
@@ -65,7 +65,8 @@ public class CreatePDFFromDynamicHTML {
             FileRef result = htmlToPDFOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs(createOutputFileDirectoryPath("output/CreatePDFFromDynamicHTML", "Create", "pdf"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -97,11 +98,11 @@ public class CreatePDFFromDynamicHTML {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/CreatePDFFromDynamicHTML/create" + timeStamp + ".pdf");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromHTMLWithInlineCSS.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromHTMLWithInlineCSS.java
@@ -61,7 +61,8 @@ public class CreatePDFFromHTMLWithInlineCSS {
             FileRef result = htmlToPDFOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs(createOutputFileDirectoryPath("output/CreatePDFFromHTMLWithInlineCSS", "Create", "pdf"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -88,11 +89,11 @@ public class CreatePDFFromHTMLWithInlineCSS {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/CreatePDFFromHTMLWithInlineCSS/create" + timeStamp + ".pdf");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromHTMLWithInlineCSS.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromHTMLWithInlineCSS.java
@@ -24,6 +24,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * This sample illustrates how to create a PDF file from an HTML file with inline CSS.
@@ -59,7 +61,7 @@ public class CreatePDFFromHTMLWithInlineCSS {
             FileRef result = htmlToPDFOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs("output/createPDFFromHTMLWithInlineCSSOutput.pdf");
+            result.saveAs(createOutputFileDirectoryPath("output/CreatePDFFromHTMLWithInlineCSS", "Create", "pdf"));
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -83,6 +85,14 @@ public class CreatePDFFromHTMLWithInlineCSS {
                 .withPageLayout(pageLayout)
                 .build();
         htmlToPDFOperation.setOptions(htmlToPdfOptions);
+    }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromPPTX.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromPPTX.java
@@ -57,7 +57,8 @@ public class CreatePDFFromPPTX {
             FileRef result = createPdfOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs(createOutputFileDirectoryPath("output/CreatePDFFromPPTX", "Create", "pdf"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -66,11 +67,11 @@ public class CreatePDFFromPPTX {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/CreatePDFFromPPTX/create" + timeStamp + ".pdf");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromPPTX.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromPPTX.java
@@ -12,6 +12,8 @@
 package com.adobe.pdfservices.operation.samples.createpdf;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,11 +57,20 @@ public class CreatePDFFromPPTX {
             FileRef result = createPdfOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs("output/createPDFFromPPTX.pdf");
+            result.saveAs(createOutputFileDirectoryPath("output/CreatePDFFromPPTX", "Create", "pdf"));
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
         }
 
     }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
+
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromStaticHTML.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromStaticHTML.java
@@ -63,7 +63,8 @@ public class CreatePDFFromStaticHTML {
             FileRef result = htmlToPDFOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs(createOutputFileDirectoryPath("output/CreatePDFFromStaticHTML", "Create", "pdf"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -89,11 +90,11 @@ public class CreatePDFFromStaticHTML {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/CreatePDFFromStaticHTML/create" + timeStamp + ".pdf");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromStaticHTML.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromStaticHTML.java
@@ -12,6 +12,8 @@
 package com.adobe.pdfservices.operation.samples.createpdf;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,7 +63,7 @@ public class CreatePDFFromStaticHTML {
             FileRef result = htmlToPDFOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs("output/createPDFFromStaticHtmlOutput.pdf");
+            result.saveAs(createOutputFileDirectoryPath("output/CreatePDFFromStaticHTML", "Create", "pdf"));
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -84,6 +86,14 @@ public class CreatePDFFromStaticHTML {
                 .withPageLayout(pageLayout)
                 .build();
         htmlToPDFOperation.setOptions(htmlToPdfOptions);
+    }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromURL.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromURL.java
@@ -68,7 +68,8 @@ public class CreatePDFFromURL {
             FileRef result = htmlToPDFOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs(createOutputFileDirectoryPath("output/CreatePDFFromURL", "Create", "pdf"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -94,11 +95,11 @@ public class CreatePDFFromURL {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/CreatePDFFromURL/create" + timeStamp + ".pdf");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromURL.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFFromURL.java
@@ -25,6 +25,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URL;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * This sample illustrates how to convert an HTML file specified via URL to a PDF file.
@@ -66,7 +68,7 @@ public class CreatePDFFromURL {
             FileRef result = htmlToPDFOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs("output/createPDFFromURLOutput.pdf");
+            result.saveAs(createOutputFileDirectoryPath("output/CreatePDFFromURL", "Create", "pdf"));
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -90,4 +92,13 @@ public class CreatePDFFromURL {
                 .build();
         htmlToPDFOperation.setOptions(htmlToPdfOptions);
     }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
+
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFWithCustomTimeouts.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFWithCustomTimeouts.java
@@ -66,7 +66,8 @@ public class CreatePDFWithCustomTimeouts {
             FileRef result = createPDFOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs(createOutputFileDirectoryPath("output/CreatePDFWithCustomTimeouts", "Create", "pdf"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -74,11 +75,11 @@ public class CreatePDFWithCustomTimeouts {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/CreatePDFWithCustomTimeouts/create" + timeStamp + ".pdf");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFWithCustomTimeouts.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFWithCustomTimeouts.java
@@ -12,6 +12,8 @@
 package com.adobe.pdfservices.operation.samples.createpdf;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import com.adobe.pdfservices.operation.ClientConfig;
 import org.slf4j.Logger;
@@ -64,10 +66,19 @@ public class CreatePDFWithCustomTimeouts {
             FileRef result = createPDFOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs("output/createPDFWithCustomTimeouts.pdf");
+            result.saveAs(createOutputFileDirectoryPath("output/CreatePDFWithCustomTimeouts", "Create", "pdf"));
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
         }
     }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
+
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFWithInMemoryAuthCredentials.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFWithInMemoryAuthCredentials.java
@@ -68,7 +68,8 @@ public class CreatePDFWithInMemoryAuthCredentials {
             FileRef result = createPDFOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs(createOutputFileDirectoryPath("output/CreatePDFWithInMemCredentials", "Create", "pdf"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -76,11 +77,11 @@ public class CreatePDFWithInMemoryAuthCredentials {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/CreatePDFWithInMemCredentials/create" + timeStamp + ".pdf");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFWithInMemoryAuthCredentials.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFWithInMemoryAuthCredentials.java
@@ -12,6 +12,8 @@
 package com.adobe.pdfservices.operation.samples.createpdf;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,10 +68,19 @@ public class CreatePDFWithInMemoryAuthCredentials {
             FileRef result = createPDFOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs("output/createPDFWithInMemCredentials.pdf");
+            result.saveAs(createOutputFileDirectoryPath("output/CreatePDFWithInMemCredentials", "Create", "pdf"));
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
         }
     }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
+
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFWithProxyServer.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFWithProxyServer.java
@@ -75,7 +75,8 @@ public class CreatePDFWithProxyServer {
             FileRef result = createPDFOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs(createOutputFileDirectoryPath("output/CreatePDFWithProxyServer", "Create", "pdf"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -83,11 +84,11 @@ public class CreatePDFWithProxyServer {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/CreatePDFWithProxyServer/create" + timeStamp + ".pdf");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFWithProxyServer.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/createpdf/CreatePDFWithProxyServer.java
@@ -23,6 +23,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * This sample illustrates how to setup Proxy Server configurations for performing an operation. This enables the
@@ -73,10 +75,19 @@ public class CreatePDFWithProxyServer {
             FileRef result = createPDFOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs("output/createPDFWithProxyServer.pdf");
+            result.saveAs(createOutputFileDirectoryPath("output/CreatePDFWithProxyServer", "Create", "pdf"));
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
         }
     }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
+
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/deletepages/DeletePDFPages.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/deletepages/DeletePDFPages.java
@@ -23,6 +23,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * This sample illustrates how to delete pages in a PDF file.
@@ -57,7 +59,7 @@ public class DeletePDFPages {
             FileRef result = deletePagesOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs("output/deletePagesOutput.pdf");
+            result.saveAs(createOutputFileDirectoryPath("output/DeletePDFPages", "Delete", "pdf"));
 
         } catch (IOException | ServiceApiException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
@@ -74,4 +76,13 @@ public class DeletePDFPages {
         pageRangeForDeletion.addRange(3, 4);
         return pageRangeForDeletion;
     }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
+
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/deletepages/DeletePDFPages.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/deletepages/DeletePDFPages.java
@@ -59,7 +59,8 @@ public class DeletePDFPages {
             FileRef result = deletePagesOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs(createOutputFileDirectoryPath("output/DeletePDFPages", "Delete", "pdf"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (IOException | ServiceApiException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
@@ -78,11 +79,11 @@ public class DeletePDFPages {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/DeletePDFPages/delete" + timeStamp + ".pdf");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/documentmerge/MergeDocumentToDOCX.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/documentmerge/MergeDocumentToDOCX.java
@@ -26,6 +26,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * This sample illustrates how to merge the Word based document template with the input JSON data to generate
@@ -90,10 +92,19 @@ public class MergeDocumentToDOCX {
             FileRef result = documentMergeOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs("output/documentMergeOutput.docx");
+            result.saveAs(createOutputFileDirectoryPath("output/MergeDocumentToDOCX", "Merge", "docx"));
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
         }
     }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
+
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/documentmerge/MergeDocumentToDOCX.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/documentmerge/MergeDocumentToDOCX.java
@@ -92,7 +92,8 @@ public class MergeDocumentToDOCX {
             FileRef result = documentMergeOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs(createOutputFileDirectoryPath("output/MergeDocumentToDOCX", "Merge", "docx"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -100,11 +101,11 @@ public class MergeDocumentToDOCX {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/MergeDocumentToDOCX/merge" + timeStamp + ".docx");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/documentmerge/MergeDocumentToDOCXWithFragments.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/documentmerge/MergeDocumentToDOCXWithFragments.java
@@ -26,6 +26,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * This sample illustrates how to merge the Word based document template with the input JSON data and fragments JSON to generate
@@ -106,10 +108,19 @@ public class MergeDocumentToDOCXWithFragments {
             FileRef result = documentMergeOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs("output/documentMergeFragmentsOutput.docx");
+            result.saveAs(createOutputFileDirectoryPath("output/MergeDocumentToDOCXWithFragments", "Merge", "docx"));
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
         }
     }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
+
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/documentmerge/MergeDocumentToDOCXWithFragments.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/documentmerge/MergeDocumentToDOCXWithFragments.java
@@ -108,7 +108,8 @@ public class MergeDocumentToDOCXWithFragments {
             FileRef result = documentMergeOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs(createOutputFileDirectoryPath("output/MergeDocumentToDOCXWithFragments", "Merge", "docx"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -116,11 +117,11 @@ public class MergeDocumentToDOCXWithFragments {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/MergeDocumentToDOCXWithFragments/merge" + timeStamp + ".docx");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/documentmerge/MergeDocumentToPDF.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/documentmerge/MergeDocumentToPDF.java
@@ -73,7 +73,8 @@ public class MergeDocumentToPDF {
             FileRef result = documentMergeOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs(createOutputFileDirectoryPath("output/MergeDocumentToPDF", "Merge", "pdf"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -81,11 +82,11 @@ public class MergeDocumentToPDF {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/MergeDocumentToPDF/merge" + timeStamp + ".pdf");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/documentmerge/MergeDocumentToPDF.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/documentmerge/MergeDocumentToPDF.java
@@ -27,6 +27,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * This sample illustrates how to merge the Word based document template with the input JSON data to generate
@@ -71,10 +73,19 @@ public class MergeDocumentToPDF {
             FileRef result = documentMergeOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs("output/salesOrderOutput.pdf");
+            result.saveAs(createOutputFileDirectoryPath("output/MergeDocumentToPDF", "Merge", "pdf"));
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
         }
     }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
+
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/exportpdf/ExportPDFToDOCX.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/exportpdf/ExportPDFToDOCX.java
@@ -57,7 +57,8 @@ public class ExportPDFToDOCX {
             FileRef result = exportPdfOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs(createOutputFileDirectoryPath("output/ExportPDFToDOCX", "Export", "docx"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -65,11 +66,11 @@ public class ExportPDFToDOCX {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/ExportPDFToDOCX/export" + timeStamp + ".docx");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/exportpdf/ExportPDFToDOCX.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/exportpdf/ExportPDFToDOCX.java
@@ -12,6 +12,8 @@
 package com.adobe.pdfservices.operation.samples.exportpdf;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,10 +57,19 @@ public class ExportPDFToDOCX {
             FileRef result = exportPdfOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs("output/exportPdfOutput.docx");
+            result.saveAs(createOutputFileDirectoryPath("output/ExportPDFToDOCX", "Export", "docx"));
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
         }
     }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
+
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/exportpdf/ExportPDFToDOCXWithOCROption.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/exportpdf/ExportPDFToDOCXWithOCROption.java
@@ -61,7 +61,8 @@ public class ExportPDFToDOCXWithOCROption {
             FileRef result = exportPDFOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs(createOutputFileDirectoryPath("output/ExportPDFToDOCXWithOCROption", "Export", "docx"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -69,11 +70,11 @@ public class ExportPDFToDOCXWithOCROption {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/ExportPDFToDOCXWithOCROption/export" + timeStamp + ".docx");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/exportpdf/ExportPDFToDOCXWithOCROption.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/exportpdf/ExportPDFToDOCXWithOCROption.java
@@ -24,6 +24,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * This sample illustrates how to export a PDF file to a Word (DOCX) file. The OCR processing is also performed on the input PDF file to extract text from images in the document.
@@ -59,10 +61,19 @@ public class ExportPDFToDOCXWithOCROption {
             FileRef result = exportPDFOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs("output/exportPDFWithOCROptionsOutput.docx");
+            result.saveAs(createOutputFileDirectoryPath("output/ExportPDFToDOCXWithOCROption", "Export", "docx"));
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
         }
     }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
+
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/exportpdftoimages/ExportPDFToJPEG.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/exportpdftoimages/ExportPDFToJPEG.java
@@ -23,6 +23,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 /**
@@ -57,7 +59,7 @@ public class ExportPDFToJPEG {
             // Save the result to the specified location.
             int index = 0;
             for(FileRef result : results) {
-                result.saveAs("output/exportPDFToJPEGOutput_" + index + ".jpeg");
+                result.saveAs(createOutputFileDirectoryPathWithIndex("output/ExportPDFToJPEG", "Export", index, "jpeg"));
                 index++;
             }
 
@@ -65,4 +67,13 @@ public class ExportPDFToJPEG {
             LOGGER.error("Exception encountered while executing operation", ex);
         }
     }
+
+    //Generates a string containing a directory structure and indexed file name for the output file.
+    public static String createOutputFileDirectoryPathWithIndex(String directory, String name, int index, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "_" + index + "." + format);
+    }
+
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/exportpdftoimages/ExportPDFToJPEG.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/exportpdftoimages/ExportPDFToJPEG.java
@@ -57,9 +57,11 @@ public class ExportPDFToJPEG {
             List<FileRef> results = exportPDFToImagesOperation.execute(executionContext);
 
             // Save the result to the specified location.
+            String outputFilePath = createOutputFilePath();
             int index = 0;
             for(FileRef result : results) {
-                result.saveAs(createOutputFileDirectoryPathWithIndex("output/ExportPDFToJPEG", "Export", index, "jpeg"));
+                String saveOutputFilePath = String.format(outputFilePath, String.valueOf(index));
+                result.saveAs(saveOutputFilePath);
                 index++;
             }
 
@@ -69,11 +71,11 @@ public class ExportPDFToJPEG {
     }
 
     //Generates a string containing a directory structure and indexed file name for the output file.
-    public static String createOutputFileDirectoryPathWithIndex(String directory, String name, int index, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "_" + index + "." + format);
+        return ("output/ExportPDFToJPEG/export" + timeStamp + "_%s.jpeg");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/exportpdftoimages/ExportPDFToJPEGZip.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/exportpdftoimages/ExportPDFToJPEGZip.java
@@ -65,7 +65,8 @@ public class ExportPDFToJPEGZip {
             LOGGER.info("Media type of the received asset is "+ results.get(0).getMediaType());
 
             // Save the result to the specified location.
-            results.get(0).saveAs(createOutputFileDirectoryPath("output/ExportPDFToJPEGZip", "Export", "zip"));
+            String outputFilePath = createOutputFilePath();
+            results.get(0).saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -73,11 +74,11 @@ public class ExportPDFToJPEGZip {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/ExportPDFToJPEGZip/export" + timeStamp + ".zip");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/exportpdftoimages/ExportPDFToJPEGZip.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/exportpdftoimages/ExportPDFToJPEGZip.java
@@ -24,6 +24,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 /**
@@ -63,10 +65,19 @@ public class ExportPDFToJPEGZip {
             LOGGER.info("Media type of the received asset is "+ results.get(0).getMediaType());
 
             // Save the result to the specified location.
-            results.get(0).saveAs("output/exportPDFToJPEGOutput.zip");
+            results.get(0).saveAs(createOutputFileDirectoryPath("output/ExportPDFToJPEGZip", "Export", "zip"));
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
         }
     }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
+
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextInfoFromPDF.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextInfoFromPDF.java
@@ -21,6 +21,8 @@ import com.adobe.pdfservices.operation.pdfops.options.extractpdf.ExtractPDFOptio
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 
 /**
@@ -60,11 +62,20 @@ public class ExtractTextInfoFromPDF {
             FileRef result = extractPDFOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs("output/ExtractTextInfoFromPDF.zip");
+            result.saveAs(createOutputFileDirectoryPath("output/ExtractTextInfoFromPDF", "Extract", "zip"));
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
         }
     }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
+
 }
 

--- a/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextInfoFromPDF.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextInfoFromPDF.java
@@ -62,7 +62,8 @@ public class ExtractTextInfoFromPDF {
             FileRef result = extractPDFOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs(createOutputFileDirectoryPath("output/ExtractTextInfoFromPDF", "Extract", "zip"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
@@ -70,11 +71,11 @@ public class ExtractTextInfoFromPDF {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/ExtractTextInfoFromPDF/extract" + timeStamp + ".zip");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextInfoWithCharBoundsFromPDF.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextInfoWithCharBoundsFromPDF.java
@@ -62,7 +62,8 @@ public class ExtractTextInfoWithCharBoundsFromPDF {
             FileRef result = extractPDFOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs(createOutputFileDirectoryPath("output/ExtractTextInfoWithCharBoundsFromPDF", "Extract", "zip"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
@@ -70,11 +71,11 @@ public class ExtractTextInfoWithCharBoundsFromPDF {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/ExtractTextInfoWithCharBoundsFromPDF/extract" + timeStamp + ".zip");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextInfoWithCharBoundsFromPDF.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextInfoWithCharBoundsFromPDF.java
@@ -10,6 +10,9 @@
 package com.adobe.pdfservices.operation.samples.extractpdf;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 import com.adobe.pdfservices.operation.ExecutionContext;
 import com.adobe.pdfservices.operation.auth.Credentials;
 import com.adobe.pdfservices.operation.exception.SdkException;
@@ -59,10 +62,19 @@ public class ExtractTextInfoWithCharBoundsFromPDF {
             FileRef result = extractPDFOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs("output/ExtractTextInfoWithCharBoundsFromPDF.zip");
+            result.saveAs(createOutputFileDirectoryPath("output/ExtractTextInfoWithCharBoundsFromPDF", "Extract", "zip"));
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
         }
     }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
+
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextTableInfoFromPDF.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextTableInfoFromPDF.java
@@ -10,6 +10,8 @@
 package com.adobe.pdfservices.operation.samples.extractpdf;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import com.adobe.pdfservices.operation.ExecutionContext;
 import com.adobe.pdfservices.operation.auth.Credentials;
@@ -58,11 +60,20 @@ public class ExtractTextTableInfoFromPDF {
             FileRef result = extractPDFOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs("output/ExtractTextTableInfoFromPDF.zip");
+            result.saveAs(createOutputFileDirectoryPath("output/ExtractTextTableInfoFromPDF", "Extract", "zip"));
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
         }
     }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
+
 }
 

--- a/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextTableInfoFromPDF.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextTableInfoFromPDF.java
@@ -60,7 +60,8 @@ public class ExtractTextTableInfoFromPDF {
             FileRef result = extractPDFOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs(createOutputFileDirectoryPath("output/ExtractTextTableInfoFromPDF", "Extract", "zip"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
@@ -68,11 +69,11 @@ public class ExtractTextTableInfoFromPDF {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/ExtractTextTableInfoFromPDF/extract" + timeStamp + ".zip");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextTableInfoWithCharBoundsFromPDF.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextTableInfoWithCharBoundsFromPDF.java
@@ -10,6 +10,8 @@
 package com.adobe.pdfservices.operation.samples.extractpdf;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import com.adobe.pdfservices.operation.ExecutionContext;
 import com.adobe.pdfservices.operation.auth.Credentials;
@@ -61,10 +63,19 @@ public class ExtractTextTableInfoWithCharBoundsFromPDF {
             FileRef result = extractPDFOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs("output/ExtractTextTableInfoWithCharBoundsFromPDF.zip");
+            result.saveAs(createOutputFileDirectoryPath("output/ExtractTextTableInfoWithCharBoundsFromPDF", "Extract", "zip"));
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
         }
     }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
+
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextTableInfoWithCharBoundsFromPDF.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextTableInfoWithCharBoundsFromPDF.java
@@ -63,7 +63,8 @@ public class ExtractTextTableInfoWithCharBoundsFromPDF {
             FileRef result = extractPDFOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs(createOutputFileDirectoryPath("output/ExtractTextTableInfoWithCharBoundsFromPDF", "Extract", "zip"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
@@ -71,11 +72,11 @@ public class ExtractTextTableInfoWithCharBoundsFromPDF {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/ExtractTextTableInfoWithCharBoundsFromPDF/extract" + timeStamp + ".zip");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextTableInfoWithFiguresTablesRenditionsFromPDF.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextTableInfoWithFiguresTablesRenditionsFromPDF.java
@@ -64,9 +64,8 @@ public class ExtractTextTableInfoWithFiguresTablesRenditionsFromPDF {
             FileRef result = extractPDFOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs(createOutputFileDirectoryPath("output/ExtractTextTableInfoWithFiguresTablesRenditionsFromPDF",
-                    "Extract", "zip"));
-
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
@@ -74,11 +73,11 @@ public class ExtractTextTableInfoWithFiguresTablesRenditionsFromPDF {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/ExtractTextTableInfoWithFiguresTablesRenditionsFromPDF/extract" + timeStamp + ".zip");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextTableInfoWithFiguresTablesRenditionsFromPDF.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextTableInfoWithFiguresTablesRenditionsFromPDF.java
@@ -10,6 +10,8 @@
 package com.adobe.pdfservices.operation.samples.extractpdf;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import com.adobe.pdfservices.operation.ExecutionContext;
 import com.adobe.pdfservices.operation.auth.Credentials;
@@ -62,10 +64,21 @@ public class ExtractTextTableInfoWithFiguresTablesRenditionsFromPDF {
             FileRef result = extractPDFOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs("output/ExtractTextTableInfoWithFiguresTablesRenditionsFromPDF.zip");
+            result.saveAs(createOutputFileDirectoryPath("output/ExtractTextTableInfoWithFiguresTablesRenditionsFromPDF",
+                    "Extract", "zip"));
+
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
         }
     }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
+
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextTableInfoWithRenditionsFromPDF.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextTableInfoWithRenditionsFromPDF.java
@@ -10,6 +10,8 @@
 package com.adobe.pdfservices.operation.samples.extractpdf;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import com.adobe.pdfservices.operation.ExecutionContext;
 import com.adobe.pdfservices.operation.auth.Credentials;
@@ -61,10 +63,20 @@ public class ExtractTextTableInfoWithRenditionsFromPDF {
             FileRef result = extractPDFOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs("output/ExtractTextTableInfoWithRenditionsFromPDF.zip");
+            result.saveAs(createOutputFileDirectoryPath("output/ExtractTextTableInfoWithRenditionsFromPDF",
+                    "Extract", "zip"));
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
         }
     }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
+
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextTableInfoWithRenditionsFromPDF.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextTableInfoWithRenditionsFromPDF.java
@@ -63,8 +63,8 @@ public class ExtractTextTableInfoWithRenditionsFromPDF {
             FileRef result = extractPDFOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs(createOutputFileDirectoryPath("output/ExtractTextTableInfoWithRenditionsFromPDF",
-                    "Extract", "zip"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
@@ -72,11 +72,11 @@ public class ExtractTextTableInfoWithRenditionsFromPDF {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/ExtractTextTableInfoWithRenditionsFromPDF/extract" + timeStamp + ".zip");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextTableInfoWithStylingFromPDF.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextTableInfoWithStylingFromPDF.java
@@ -10,6 +10,8 @@
 package com.adobe.pdfservices.operation.samples.extractpdf;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import com.adobe.pdfservices.operation.ExecutionContext;
 import com.adobe.pdfservices.operation.auth.Credentials;
@@ -60,10 +62,20 @@ public class ExtractTextTableInfoWithStylingFromPDF {
             FileRef result = extractPDFOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs("output/ExtractTextTableInfoWithStylingFromPDF.zip");
+            result.saveAs(createOutputFileDirectoryPath("output/ExtractTextTableInfoWithStylingFromPDF",
+                    "Extract", "zip"));
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
         }
     }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
+
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextTableInfoWithStylingFromPDF.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextTableInfoWithStylingFromPDF.java
@@ -62,8 +62,8 @@ public class ExtractTextTableInfoWithStylingFromPDF {
             FileRef result = extractPDFOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs(createOutputFileDirectoryPath("output/ExtractTextTableInfoWithStylingFromPDF",
-                    "Extract", "zip"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
@@ -71,11 +71,11 @@ public class ExtractTextTableInfoWithStylingFromPDF {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/ExtractTextTableInfoWithStylingFromPDF/extract" + timeStamp + ".zip");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextTableInfoWithTableStructureFromPdf.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextTableInfoWithTableStructureFromPdf.java
@@ -10,6 +10,8 @@
 package com.adobe.pdfservices.operation.samples.extractpdf;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import com.adobe.pdfservices.operation.ExecutionContext;
 import com.adobe.pdfservices.operation.auth.Credentials;
@@ -64,10 +66,20 @@ public class ExtractTextTableInfoWithTableStructureFromPdf {
             FileRef result = extractPDFOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs("output/ExtractTextTableInfoWithTableStructureFromPdf.zip");
+            result.saveAs(createOutputFileDirectoryPath("output/ExtractTextTableInfoWithTableStructureFromPDF",
+                    "Extract", "zip"));
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
         }
     }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
+
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextTableInfoWithTableStructureFromPdf.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/extractpdf/ExtractTextTableInfoWithTableStructureFromPdf.java
@@ -66,8 +66,8 @@ public class ExtractTextTableInfoWithTableStructureFromPdf {
             FileRef result = extractPDFOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs(createOutputFileDirectoryPath("output/ExtractTextTableInfoWithTableStructureFromPDF",
-                    "Extract", "zip"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
@@ -75,11 +75,11 @@ public class ExtractTextTableInfoWithTableStructureFromPdf {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/ExtractTextTableInfoWithTableStructureFromPDF/extract" + timeStamp + ".zip");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/insertpages/InsertPDFPages.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/insertpages/InsertPDFPages.java
@@ -23,6 +23,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * This sample illustrates how to insert specific pages of multiple PDF files into a single PDF file.
@@ -68,7 +70,7 @@ public class InsertPDFPages {
             FileRef result = insertPagesOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs("output/insertPagesOutput.pdf");
+            result.saveAs(createOutputFileDirectoryPath("output/InsertPDFPages", "Insert", "pdf"));
 
         } catch (IOException | ServiceApiException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
@@ -85,6 +87,14 @@ public class InsertPDFPages {
         pageRanges.addSinglePage(4);
 
         return pageRanges;
+    }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/insertpages/InsertPDFPages.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/insertpages/InsertPDFPages.java
@@ -70,7 +70,8 @@ public class InsertPDFPages {
             FileRef result = insertPagesOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs(createOutputFileDirectoryPath("output/InsertPDFPages", "Insert", "pdf"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (IOException | ServiceApiException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
@@ -90,11 +91,11 @@ public class InsertPDFPages {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/InsertPDFPages/insert" + timeStamp + ".pdf");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/linearizepdf/LinearizePDF.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/linearizepdf/LinearizePDF.java
@@ -22,6 +22,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * This sample illustrates how to convert a PDF file into a Linearized (also known as "web optimized") PDF file.
@@ -53,10 +55,19 @@ public class LinearizePDF {
             FileRef result = linearizePDFOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs("output/linearizePDFOutput.pdf");
+            result.saveAs(createOutputFileDirectoryPath("output/LinearizePDF", "Linearize", "pdf"));
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
         }
     }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
+
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/linearizepdf/LinearizePDF.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/linearizepdf/LinearizePDF.java
@@ -55,7 +55,8 @@ public class LinearizePDF {
             FileRef result = linearizePDFOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs(createOutputFileDirectoryPath("output/LinearizePDF", "Linearize", "pdf"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -63,11 +64,11 @@ public class LinearizePDF {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/LinearizePDF/linearize" + timeStamp + ".pdf");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/ocrpdf/OcrPDF.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/ocrpdf/OcrPDF.java
@@ -59,7 +59,8 @@ public class OcrPDF {
             FileRef result = ocrOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs(createOutputFileDirectoryPath("output/OcrPDF", "OCR", "pdf"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -67,11 +68,11 @@ public class OcrPDF {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/OcrPDF/ocr" + timeStamp + ".pdf");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/ocrpdf/OcrPDF.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/ocrpdf/OcrPDF.java
@@ -12,6 +12,8 @@
 package com.adobe.pdfservices.operation.samples.ocrpdf;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,10 +59,19 @@ public class OcrPDF {
             FileRef result = ocrOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs("output/ocrOutput.pdf");
+            result.saveAs(createOutputFileDirectoryPath("output/OcrPDF", "OCR", "pdf"));
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
         }
     }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
+
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/ocrpdf/OcrPDFWithOptions.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/ocrpdf/OcrPDFWithOptions.java
@@ -12,6 +12,8 @@
 package com.adobe.pdfservices.operation.samples.ocrpdf;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,10 +71,19 @@ public class OcrPDFWithOptions {
             FileRef result = ocrOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs("output/ocrWithOptionsOutput.pdf");
+            result.saveAs(createOutputFileDirectoryPath("output/OcrPDFWithOptions", "OCR", "pdf"));
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
         }
     }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
+
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/ocrpdf/OcrPDFWithOptions.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/ocrpdf/OcrPDFWithOptions.java
@@ -71,7 +71,8 @@ public class OcrPDFWithOptions {
             FileRef result = ocrOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs(createOutputFileDirectoryPath("output/OcrPDFWithOptions", "OCR", "pdf"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -79,11 +80,11 @@ public class OcrPDFWithOptions {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/OcrPDFWithOptions/ocr" + timeStamp + ".pdf");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/protectpdf/ProtectPDF.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/protectpdf/ProtectPDF.java
@@ -24,6 +24,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * This sample illustrates how to convert a PDF file into a password protected PDF file.
@@ -64,10 +66,19 @@ public class ProtectPDF {
             FileRef result = protectPDFOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs("output/protectPDFOutput.pdf");
+            result.saveAs(createOutputFileDirectoryPath("output/ProtectPDF", "Protected", "pdf"));
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
         }
     }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
+
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/protectpdf/ProtectPDF.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/protectpdf/ProtectPDF.java
@@ -66,7 +66,8 @@ public class ProtectPDF {
             FileRef result = protectPDFOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs(createOutputFileDirectoryPath("output/ProtectPDF", "Protected", "pdf"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -74,11 +75,11 @@ public class ProtectPDF {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/ProtectPDF/protect" + timeStamp + ".pdf");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/protectpdf/ProtectPDFWithOwnerPassword.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/protectpdf/ProtectPDFWithOwnerPassword.java
@@ -12,6 +12,8 @@
 package com.adobe.pdfservices.operation.samples.protectpdf;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -77,10 +79,19 @@ public class ProtectPDFWithOwnerPassword {
             FileRef result = protectPDFOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs("output/protectPDFWithOwnerPasswordOutput.pdf");
+            result.saveAs(createOutputFileDirectoryPath("output/ProtectPDFWithOwnerPassword", "Protected", "pdf"));
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
         }
     }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
+
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/protectpdf/ProtectPDFWithOwnerPassword.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/protectpdf/ProtectPDFWithOwnerPassword.java
@@ -79,7 +79,8 @@ public class ProtectPDFWithOwnerPassword {
             FileRef result = protectPDFOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs(createOutputFileDirectoryPath("output/ProtectPDFWithOwnerPassword", "Protected", "pdf"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (ServiceApiException | IOException | SdkException | ServiceUsageException ex) {
             LOGGER.error("Exception encountered while executing operation", ex);
@@ -87,11 +88,11 @@ public class ProtectPDFWithOwnerPassword {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/ProtectPDFWithOwnerPassword/protect" + timeStamp + ".pdf");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/removeprotection/RemoveProtection.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/removeprotection/RemoveProtection.java
@@ -58,7 +58,8 @@ public class RemoveProtection {
             FileRef result = removeProtectionOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs(createOutputFileDirectoryPath("output/RemoveProtection", "RemoveProtection", "pdf"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (IOException | ServiceApiException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
@@ -66,11 +67,11 @@ public class RemoveProtection {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/RemoveProtection/removeProtection" + timeStamp + ".pdf");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/removeprotection/RemoveProtection.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/removeprotection/RemoveProtection.java
@@ -12,6 +12,8 @@
 package com.adobe.pdfservices.operation.samples.removeprotection;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,10 +58,19 @@ public class RemoveProtection {
             FileRef result = removeProtectionOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs("output/removeProtectionOutput.pdf");
+            result.saveAs(createOutputFileDirectoryPath("output/RemoveProtection", "RemoveProtection", "pdf"));
 
         } catch (IOException | ServiceApiException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
         }
     }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
+
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/reorderpages/ReorderPDFPages.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/reorderpages/ReorderPDFPages.java
@@ -24,6 +24,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * This sample illustrates how to reorder the pages in a PDF file.
@@ -57,7 +59,7 @@ public class ReorderPDFPages {
             FileRef result = reorderPagesOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs("output/reorderPagesOutput.pdf");
+            result.saveAs(createOutputFileDirectoryPath("output/ReorderPDFPages", "Reorder", "pdf"));
 
         } catch (IOException | ServiceApiException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
@@ -74,6 +76,14 @@ public class ReorderPDFPages {
         pageRanges.addSinglePage(1);
 
         return pageRanges;
+    }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/reorderpages/ReorderPDFPages.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/reorderpages/ReorderPDFPages.java
@@ -59,7 +59,8 @@ public class ReorderPDFPages {
             FileRef result = reorderPagesOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs(createOutputFileDirectoryPath("output/ReorderPDFPages", "Reorder", "pdf"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (IOException | ServiceApiException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
@@ -79,11 +80,11 @@ public class ReorderPDFPages {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/ReorderPDFPages/reorder" + timeStamp + ".pdf");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/replacepages/ReplacePDFPages.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/replacepages/ReplacePDFPages.java
@@ -23,6 +23,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * This sample illustrates how to replace specific pages in a PDF file.
@@ -69,7 +71,8 @@ public class ReplacePDFPages {
             FileRef result = replacePagesOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs("output/replacePagesOutput.pdf");
+            result.saveAs(createOutputFileDirectoryPath("output/ReplacePDFPages", "Replace", "pdf"));
+
         } catch (IOException | ServiceApiException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
         }
@@ -85,6 +88,14 @@ public class ReplacePDFPages {
         pageRanges.addSinglePage(4);
 
         return pageRanges;
+    }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/replacepages/ReplacePDFPages.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/replacepages/ReplacePDFPages.java
@@ -71,7 +71,8 @@ public class ReplacePDFPages {
             FileRef result = replacePagesOperation.execute(executionContext);
 
             // Save the result at the specified location
-            result.saveAs(createOutputFileDirectoryPath("output/ReplacePDFPages", "Replace", "pdf"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (IOException | ServiceApiException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
@@ -91,11 +92,11 @@ public class ReplacePDFPages {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/ReplacePDFPages/replace" + timeStamp + ".pdf");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/rotatepages/RotatePDFPages.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/rotatepages/RotatePDFPages.java
@@ -24,6 +24,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * This sample illustrates how to rotate pages in a PDF file.
@@ -64,7 +66,7 @@ public class RotatePDFPages {
             FileRef result = rotatePagesOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs("output/rotatePagesOutput.pdf");
+            result.saveAs(createOutputFileDirectoryPath("output/RotatePDF", "Rotate", "pdf"));
 
         } catch (IOException | ServiceApiException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
@@ -90,4 +92,13 @@ public class RotatePDFPages {
 
         return secondPageRange;
     }
+
+    //Generates a string containing a directory structure and file name for the output file.
+    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+    }
+
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/rotatepages/RotatePDFPages.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/rotatepages/RotatePDFPages.java
@@ -66,7 +66,8 @@ public class RotatePDFPages {
             FileRef result = rotatePagesOperation.execute(executionContext);
 
             // Save the result to the specified location.
-            result.saveAs(createOutputFileDirectoryPath("output/RotatePDF", "Rotate", "pdf"));
+            String outputFilePath = createOutputFilePath();
+            result.saveAs(outputFilePath);
 
         } catch (IOException | ServiceApiException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
@@ -94,11 +95,11 @@ public class RotatePDFPages {
     }
 
     //Generates a string containing a directory structure and file name for the output file.
-    public static String createOutputFileDirectoryPath(String directory, String name, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "." + format);
+        return("output/RotatePDF/rotate" + timeStamp + ".pdf");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/splitpdf/SplitPDFByNumberOfPages.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/splitpdf/SplitPDFByNumberOfPages.java
@@ -59,10 +59,11 @@ public class SplitPDFByNumberOfPages {
             List<FileRef> result = splitPDFOperation.execute(executionContext);
 
             // Save the result to the specified location.
+            String outputFilePath = createOutputFilePath();
             int index = 0;
             for (FileRef fileRef : result) {
-                fileRef.saveAs(createOutputFileDirectoryPathWithIndex("output/SplitPDFByNumberOfPages",
-                        "Split", index, "pdf"));
+                String saveOutputFilePath = String.format(outputFilePath, String.valueOf(index));
+                fileRef.saveAs(saveOutputFilePath);
                 index++;
             }
 
@@ -72,11 +73,11 @@ public class SplitPDFByNumberOfPages {
     }
 
     //Generates a string containing a directory structure and indexed file name for the output file.
-    public static String createOutputFileDirectoryPathWithIndex(String directory, String name, int index, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "_" + index + "." + format);
+        return ("output/SplitPDFByNumberOfPages/split" + timeStamp + "_%s.pdf");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/splitpdf/SplitPDFByNumberOfPages.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/splitpdf/SplitPDFByNumberOfPages.java
@@ -22,6 +22,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 /**
@@ -59,13 +61,22 @@ public class SplitPDFByNumberOfPages {
             // Save the result to the specified location.
             int index = 0;
             for (FileRef fileRef : result) {
-                fileRef.saveAs("output/SplitPDFByNumberOfPagesOutput_" + index + ".pdf");
+                fileRef.saveAs(createOutputFileDirectoryPathWithIndex("output/SplitPDFByNumberOfPages",
+                        "Split", index, "pdf"));
                 index++;
             }
 
         } catch (IOException| ServiceApiException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
         }
+    }
+
+    //Generates a string containing a directory structure and indexed file name for the output file.
+    public static String createOutputFileDirectoryPathWithIndex(String directory, String name, int index, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "_" + index + "." + format);
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/splitpdf/SplitPDFByPageRanges.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/splitpdf/SplitPDFByPageRanges.java
@@ -23,6 +23,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 /**
@@ -61,7 +63,8 @@ public class SplitPDFByPageRanges {
             // Save the result to the specified location.
             int index = 0;
             for (FileRef fileRef : result) {
-                fileRef.saveAs("output/SplitPDFByPageRangesOutput_" + index + ".pdf");
+                fileRef.saveAs(createOutputFileDirectoryPathWithIndex("output/SplitPDFByPageRanges",
+                        "Split", index, "pdf"));
                 index++;
             }
 
@@ -79,6 +82,14 @@ public class SplitPDFByPageRanges {
         // Add pages 3 to 4.
         pageRanges.addRange(3, 4);
         return pageRanges;
+    }
+
+    //Generates a string containing a directory structure and indexed file name for the output file.
+    public static String createOutputFileDirectoryPathWithIndex(String directory, String name, int index, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "_" + index + "." + format);
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/splitpdf/SplitPDFByPageRanges.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/splitpdf/SplitPDFByPageRanges.java
@@ -61,10 +61,11 @@ public class SplitPDFByPageRanges {
             List<FileRef> result = splitPDFOperation.execute(executionContext);
 
             // Save the result to the specified location.
+            String outputFilePath = createOutputFilePath();
             int index = 0;
             for (FileRef fileRef : result) {
-                fileRef.saveAs(createOutputFileDirectoryPathWithIndex("output/SplitPDFByPageRanges",
-                        "Split", index, "pdf"));
+                String saveOutputFilePath = String.format(outputFilePath, String.valueOf(index));
+                fileRef.saveAs(saveOutputFilePath);
                 index++;
             }
 
@@ -85,11 +86,11 @@ public class SplitPDFByPageRanges {
     }
 
     //Generates a string containing a directory structure and indexed file name for the output file.
-    public static String createOutputFileDirectoryPathWithIndex(String directory, String name, int index, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "_" + index + "." + format);
+        return ("output/SplitPDFByPageRanges/split" + timeStamp + "_%s.pdf");
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/splitpdf/SplitPDFIntoNumberOfFiles.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/splitpdf/SplitPDFIntoNumberOfFiles.java
@@ -22,6 +22,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 /**
@@ -58,13 +60,22 @@ public class SplitPDFIntoNumberOfFiles {
             // Save the result to the specified location.
             int index = 0;
             for (FileRef fileRef : result) {
-                fileRef.saveAs("output/SplitPDFIntoNumberOfFilesOutput_" + index + ".pdf");
+                fileRef.saveAs(createOutputFileDirectoryPathWithIndex("output/SplitPDFIntoNumberOfFiles",
+                        "Split", index, "pdf"));
                 index++;
             }
 
         } catch (IOException | ServiceApiException | SdkException | ServiceUsageException e) {
             LOGGER.error("Exception encountered while executing operation", e);
         }
+    }
+
+    //Generates a string containing a directory structure and indexed file name for the output file.
+    public static String createOutputFileDirectoryPathWithIndex(String directory, String name, int index, String format ){
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        LocalDateTime now = LocalDateTime.now();
+        String timeStamp = dateTimeFormatter.format(now);
+        return ( directory + "/" + name + "_" + timeStamp + "_" + index + "." + format);
     }
 
 }

--- a/src/main/java/com/adobe/pdfservices/operation/samples/splitpdf/SplitPDFIntoNumberOfFiles.java
+++ b/src/main/java/com/adobe/pdfservices/operation/samples/splitpdf/SplitPDFIntoNumberOfFiles.java
@@ -58,10 +58,11 @@ public class SplitPDFIntoNumberOfFiles {
             List<FileRef> result = splitPDFOperation.execute(executionContext);
 
             // Save the result to the specified location.
+            String outputFilePath = createOutputFilePath();
             int index = 0;
             for (FileRef fileRef : result) {
-                fileRef.saveAs(createOutputFileDirectoryPathWithIndex("output/SplitPDFIntoNumberOfFiles",
-                        "Split", index, "pdf"));
+                String saveOutputFilePath = String.format(outputFilePath, String.valueOf(index));
+                fileRef.saveAs(saveOutputFilePath);
                 index++;
             }
 
@@ -71,11 +72,11 @@ public class SplitPDFIntoNumberOfFiles {
     }
 
     //Generates a string containing a directory structure and indexed file name for the output file.
-    public static String createOutputFileDirectoryPathWithIndex(String directory, String name, int index, String format ){
+    public static String createOutputFilePath(){
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
         LocalDateTime now = LocalDateTime.now();
         String timeStamp = dateTimeFormatter.format(now);
-        return ( directory + "/" + name + "_" + timeStamp + "_" + index + "." + format);
+        return ("output/SplitPDFIntoNumberOfFiles/split" + timeStamp + "_%s.pdf");
     }
 
 }


### PR DESCRIPTION
Changes the output format of the PDF Services Java SDK Samples so that they can be run multiple time without any exceptions. Done by making an operation based directory structure and timestamp based file naming.